### PR TITLE
Strict unions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quicksettings"
-version = "1.0.0"
+version = "1.0.1"
 description = "Manage python application config with ease."
 authors = [
     { name = "mvbosch", email = "michael@vonbosch.co.za" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,3 +69,14 @@ class EnumSettings(BaseSettings):
 @dataclass(init=False)
 class ForwardRefSettings(BaseSettings):
     ENVIRONMENT: "EnvType"
+
+
+@dataclass(init=False)
+class UnionSettings(BaseSettings):
+    NAME: str | None
+    AGE: int | None
+
+
+@dataclass(init=False)
+class MultipleUnionSettings(BaseSettings):
+    NUMBER: int | str | None  # unsupported

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -10,9 +10,11 @@ from .conftest import (
     EnvType,
     ForwardRefSettings,
     LiteralSettings,
+    MultipleUnionSettings,
     NestedDataSettings,
     NestedMappingSettings,
     NullableSettings,
+    UnionSettings,
 )
 
 
@@ -159,3 +161,17 @@ def test_forward_ref_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ENVIRONMENT", "hello")
     with pytest.raises(ValueError):
         ForwardRefSettings()
+
+
+def test_union_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NAME", "karl")
+    monkeypatch.setenv("AGE", "999")
+    settings = UnionSettings()
+    assert settings.NAME == "karl"
+    assert settings.AGE == 999
+
+
+def test_multiple_union_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NAME", "karl")
+    with pytest.raises(ValueError):
+        MultipleUnionSettings()


### PR DESCRIPTION
Add stricter checking to type unions.

Fixes a bug where a union could get passed to a `issubclass` check.